### PR TITLE
Deleted unnecessary `if` checking.

### DIFF
--- a/10. Populating Next Right Pointers in Each Node/solution.h
+++ b/10. Populating Next Right Pointers in Each Node/solution.h
@@ -13,12 +13,11 @@ public:
         while (root->left)
         {
             root->left->next = root->right;
-            if (root->next)
-                for (TreeLinkNode *cur = root; cur->next; cur = cur->next)
-                {
-                    cur->right->next = cur->next->left;
-                    cur->next->left->next = cur->next->right;
-                }
+            for (TreeLinkNode *cur = root; cur->next; cur = cur->next)
+            {
+                cur->right->next = cur->next->left;
+                cur->next->left->next = cur->next->right;
+            }
             root = root->left;
         }
     }


### PR DESCRIPTION
The `cur->next` from the following code provides the same functionality.
`for (TreeLinkNode *cur = root; cur->next; cur = cur->next)`
